### PR TITLE
Add: missing <memory> header ?

### DIFF
--- a/06_Menus/Include/Book/Label.hpp
+++ b/06_Menus/Include/Book/Label.hpp
@@ -7,6 +7,7 @@
 
 #include <SFML/Graphics/Text.hpp>
 
+#include <memory>
 
 namespace GUI
 {


### PR DESCRIPTION
std::shared_ptr is used at line 18